### PR TITLE
Report offline clients even if not found in socketClients

### DIFF
--- a/snub-ws.js
+++ b/snub-ws.js
@@ -229,10 +229,7 @@ module.exports = function (config) {
         var idx = trackedClients.findIndex((tc) => tc.id === clientId);
         if (idx > -1) {
           var rClient = trackedClients.splice(idx, 1)[0];
-          var socketClient = socketClients.find(
-            (sc) => sc.state.id === clientId
-          );
-          if (socketClient) clients.push(rClient);
+          clients.push(rClient);
         }
       });
       if (clients.length)


### PR DESCRIPTION
When debugging this `socketClients` was sometimes an empty array, even with lots of clients connected at a given time. When a client went offline while this was the case the consuming server process did not receive an offline event for that client.

There is probably an underlying issue why `socketClients` is empty in the first place, but could not found the reason for it.